### PR TITLE
Support working paths with spaces

### DIFF
--- a/wt
+++ b/wt
@@ -16,15 +16,6 @@ worktree_list() {
 	git worktree list
 }
 
-# Parses out the directory from the worktree string
-get_tree_path() {
-	tree_arr=($@)
-	# Remove last 2 array elements to get path only
-	unset tree_arr[${#tree_arr[@]}-1] # Branch name
-	unset tree_arr[${#tree_arr[@]}-1] # HEAD commit ID
-	echo ${tree_arr[*]}
-}
-
 help_message() {
 	echo -e "wt lets you switch between your git worktrees with speed.\n"
 	echo "Usage:"
@@ -36,8 +27,7 @@ help_message() {
 }
 
 goto_main_worktree() {
-	main_worktree=$(git worktree list | awk -F "\t" 'NR==1 {print $1}')
-	directory=$(get_tree_path "$main_worktree")
+	directory=$(git worktree list --porcelain | awk '$1=="worktree" {print substr($0, 10); exit}') # Skips 'worktree ' at start of string
 
 	if [ -z "$directory" ]; then
 		:
@@ -105,8 +95,7 @@ version)
 	goto_main_worktree
 	;;
 *)
-	worktree=$(git worktree list | awk -F "\t" '/'"${args[0]}"'/ {print $1}' | awk -F "\t" 'NR==1 {print $1}')
-	directory=$(get_tree_path "$worktree")
+	directory=$(git worktree list --porcelain | awk '/'"${args[0]}"'/ {print; exit}' | awk '$1=="worktree" {print substr($0, 10); exit}') # Skips 'worktree ' at start of string
 	;;
 esac
 

--- a/wt
+++ b/wt
@@ -16,6 +16,15 @@ worktree_list() {
 	git worktree list
 }
 
+# Parses out the directory from the worktree string
+get_tree_path() {
+	tree_arr=($@)
+	# Remove last 2 array elements to get path only
+	unset tree_arr[${#tree_arr[@]}-1] # Branch name
+	unset tree_arr[${#tree_arr[@]}-1] # HEAD commit ID
+	echo ${tree_arr[*]}
+}
+
 help_message() {
 	echo -e "wt lets you switch between your git worktrees with speed.\n"
 	echo "Usage:"
@@ -27,13 +36,14 @@ help_message() {
 }
 
 goto_main_worktree() {
-	main_worktree=$(git worktree list | awk 'NR==1 {print $1}')
+	main_worktree=$(git worktree list | awk -F "\t" 'NR==1 {print $1}')
+	directory=$(get_tree_path "$main_worktree")
 
-	if [ -z "$main_worktree" ]; then
+	if [ -z "$directory" ]; then
 		:
 	else
-		echo Changing to worktree at: "$main_worktree"
-		cd "$main_worktree"
+		echo Changing to main worktree at: "$directory"
+		cd "$directory"
 		exec $SHELL
 	fi
 }
@@ -95,7 +105,8 @@ version)
 	goto_main_worktree
 	;;
 *)
-	directory=$(git worktree list | awk '/'"${args[0]}"'/ {print $1}' | awk 'NR==1 {print $1}')
+	worktree=$(git worktree list | awk -F "\t" '/'"${args[0]}"'/ {print $1}' | awk -F "\t" 'NR==1 {print $1}')
+	directory=$(get_tree_path "$worktree")
 	;;
 esac
 


### PR DESCRIPTION
Resolves [this issue](https://github.com/yankeexe/git-worktree-switcher/issues/8).

Changes:
- Added a new function for parsing out the working path from the tree strings that are output by 'git worktree list'.
- Used the new function to set the working directory instead of relying on positional parameters set by 'git worktree list'.
- Configured 'awk' calls to use tabs instead of spaces as field separators for a line.
- Distinguished the console message that is printed when switching to the main worktree.

This can possibly be programmed more elegantly, so feel free to make improvements or suggestions if you have any.