### PR TITLE
Updated the usage of the `grep` utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,6 @@ Copy the executable to any directory in your `$PATH`
 $ sudo cp wt /usr/local/bin
 ```
 
-## Note for Mac Users
-`git-work-tree switcher` relies on GNU grep, which is not avaiable on Mac.
-
-To use this tool:
-- install GNU grep
-   ```sh
-   brew install grep
-   ```
-- Add **gnubin** directory to your `PATH`
-    ```sh
-    export PATH="/opt/homebrew/opt/grep/libexec/gnubin:$PATH"
-    ```
-
 ## Tab Autocompletion :zap:
 
 **For Bash**

--- a/wt
+++ b/wt
@@ -31,7 +31,7 @@ help_message() {
 }
 
 goto_main_worktree() {
-	main_worktree=$(git worktree list --porcelain | awk '{print $0; exit}' | grep -E 'worktree ' | cut -d ' ' -f2-)
+	main_worktree=$(git worktree list --porcelain | grep -E 'worktree ' | awk '{print $0; exit}' | cut -d ' ' -f2-)
 
 	if [ -z "$main_worktree" ]; then
 		:
@@ -99,7 +99,7 @@ version)
 	goto_main_worktree
 	;;
 *)
-	directory=$(git worktree list --porcelain | awk '/'"$arg"'/ {print; exit}' | grep -E 'worktree ' | cut -d ' ' -f2-)
+	directory=$(git worktree list --porcelain | grep -E 'worktree ' | awk '/'"$arg"'/ {print; exit}' | cut -d ' ' -f2-)
 	;;
 esac
 

--- a/wt
+++ b/wt
@@ -31,7 +31,7 @@ help_message() {
 }
 
 goto_main_worktree() {
-	main_worktree=$(git worktree list --porcelain | awk '{print $0; exit}' | grep -oP '(?<=worktree ).*')
+	main_worktree=$(git worktree list --porcelain | awk '{print $0; exit}' | grep -E 'worktree ' | cut -d ' ' -f2-)
 
 	if [ -z "$main_worktree" ]; then
 		:
@@ -99,7 +99,7 @@ version)
 	goto_main_worktree
 	;;
 *)
-	directory=$(git worktree list --porcelain | awk '/'"$arg"'/ {print; exit}' | grep -oP '(?<=worktree ).*')
+	directory=$(git worktree list --porcelain | awk '/'"$arg"'/ {print; exit}' | grep -E 'worktree ' | cut -d ' ' -f2-)
 	;;
 esac
 


### PR DESCRIPTION
Updated the usage of the `grep` utility so it works both on Linux and BSD (MacOS).

Tested on Mac using:
grep (BSD grep, GNU compatible) 2.6.0-FreeBSD
ggrep (GNU grep) 3.8

Not tested on Linux