### PR TITLE
Fail silently when listing, if the user is not in a git repo

### DIFF
--- a/wt
+++ b/wt
@@ -17,7 +17,9 @@ arg=$(echo "${args[0]}" | sed 's/\//\\\//g')
 
 # show worktree list
 worktree_list() {
-	git worktree list
+	if git rev-parse --git-dir &> /dev/null; then
+		git worktree list
+	fi
 }
 
 help_message() {


### PR DESCRIPTION
Adds a check for if the current directory is part of a git repository.

This is to prevent a loud failure when trying to build auto-completion options.

Eg. in fish, when typing `wt` and trying to auto-complete outside a git repo, stderr would get polluted with git complaining and completion would stop working for the rest of the shell session duration.