### PR TITLE
Avoid creating a new shell instance when using wt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Git worktree switcher:zap:
+# Git worktree switcher :zap:
 Switch between git worktrees with speed. :zap:
 
 <img src = "https://i.imgur.com/nPdneDT.gif" width="600" alt="demo of switching between git worktrees" />
@@ -25,6 +25,11 @@ $ sudo cp wt /usr/local/bin
 sudo cp completions/wt_completion /etc/bash_completion.d
 ```
 
+Add this to the end of your `~/.bashrc`:
+```bash
+eval "$(command wt init bash)"
+```
+
 **For ZSH**
 > Note: completion file for zsh has `_` prefix
 
@@ -42,10 +47,21 @@ sudo cp completions/_wt_completion <one-of-$fpath>
 exec zsh
 ```
 
+Add this to the end of your `~/.zshrc`:
+```bash
+eval "$(command wt init zsh)"
+```
+
 **For Fish**
 ```bash
 cp completions/wt.fish ~/.config/fish/completions
 ```
+
+Add this to the end of your `~/.config/fish/config.fish`:
+```bash
+command wt init fish | source
+```
+
 ---
 Tab autocompletion works for switching between your worktrees.
 ```bash

--- a/wt
+++ b/wt
@@ -6,7 +6,7 @@ set -e
 args=("$@")
 VERSION="0.1.1"
 TMP_PATH=$(mktemp)
-BINARY_PATH=$(which wt)
+BINARY_PATH=$(realpath "$0")
 JQ_URL="https://stedolan.github.io/jq/download"
 RELEASE_URL="https://github.com/yankeexe/git-worktree-switcher/releases/latest"
 RELEASE_API_URL="https://api.github.com/repos/yankeexe/git-worktree-switcher/releases/latest"
@@ -77,24 +77,19 @@ update() {
 	fi
 }
 
+get_dest_path="\$(echo \"\$result\" | awk '/^$CHANGE_DIRECTORY_PREFIX.*/ {sub(\"$CHANGE_DIRECTORY_PREFIX\", \"\"); print; exit}')"
+
 init_bash() {
 	cat <<EOF
 wt() {
-	if ! command -v wt &> /dev/null; then
-		echo 'wt was not found in your \$PATH'
-		return 1
-	fi
-
-	result="\$(command wt "\$@")"
-	dest_path="\$(echo "\$result" | awk '/^$CHANGE_DIRECTORY_PREFIX.*/ {sub("$CHANGE_DIRECTORY_PREFIX", ""); print; exit}')"
+	result="\$($BINARY_PATH "\$@")"
+	dest_path="$get_dest_path"
 
 	if [[ -n "\$dest_path" ]]; then
 		cd "\$dest_path" || return
 	elif [[ -n \$result ]]; then
 		echo "\$result"
 	fi
-
-	return 0
 }
 EOF
 }
@@ -102,13 +97,8 @@ EOF
 init_fish() {
 	cat <<EOF
 function wt
-	if ! command -q wt
-		echo 'wt was not found in your \$PATH'
-		return 1
-	end
-
-	set -l result "\$(command wt \$argv)"
-	set -l dest_path "\$(echo "\$result" | awk '/^$CHANGE_DIRECTORY_PREFIX.*/ {sub("$CHANGE_DIRECTORY_PREFIX", ""); print; exit}')"
+	set -l result "\$($BINARY_PATH \$argv)"
+	set -l dest_path "$get_dest_path"
 
 	if test -n "\$dest_path"
 		cd "\$dest_path"

--- a/wt
+++ b/wt
@@ -10,6 +10,7 @@ BINARY_PATH=$(which wt)
 JQ_URL="https://stedolan.github.io/jq/download"
 RELEASE_URL="https://github.com/yankeexe/git-worktree-switcher/releases/latest"
 RELEASE_API_URL="https://api.github.com/repos/yankeexe/git-worktree-switcher/releases/latest"
+CHANGE_DIRECTORY_PREFIX="changedir:"
 
 
 # Escape forward slash
@@ -27,6 +28,7 @@ help_message() {
 	echo -e "\twt list: list out all the git worktrees."
 	echo -e "\twt update: update to the latest release of worktree switcher."
 	echo -e "\twt version: show the CLI version."
+	echo -e "\twt init <shell>: print the init script for <shell>."
 	echo -e "\twt help: shows this help message."
 }
 
@@ -36,9 +38,7 @@ goto_main_worktree() {
 	if [ -z "$main_worktree" ]; then
 		:
 	else
-		echo Changing to main worktree at: "$main_worktree"
-		cd "$main_worktree"
-		exec $SHELL
+		directory=$main_worktree
 	fi
 }
 
@@ -77,6 +77,69 @@ update() {
 	fi
 }
 
+init_bash() {
+	cat <<EOF
+wt() {
+	if ! command -v wt &> /dev/null; then
+		echo "wt was not found in your \\\$PATH"
+		return 1
+	fi
+
+	result="\$(command wt "\$@")"
+	dest_path="\$(echo "\$result" | awk '/^$CHANGE_DIRECTORY_PREFIX.*/ {sub("$CHANGE_DIRECTORY_PREFIX", ""); print; exit}')"
+
+	if [[ -n "\$dest_path" ]]; then
+		cd "\$dest_path" || return
+	elif [[ -n \$result ]]; then
+		echo "\$result"
+	fi
+
+	return 0
+}
+EOF
+}
+
+init_fish() {
+	cat <<EOF
+function wt
+	if ! command -q wt
+		echo "wt was not found in your \\\$PATH"
+		return 1
+	end
+
+	set -l result "\$(command wt \$argv)"
+	set -l dest_path "\$(echo "\$result" | awk '/^$CHANGE_DIRECTORY_PREFIX.*/ {sub("$CHANGE_DIRECTORY_PREFIX", ""); print; exit}')"
+
+	if test -n "\$dest_path"
+		cd "\$dest_path"
+	else if test -n "\$result"
+		echo "\$result"
+	end
+end
+EOF
+}
+
+init() {
+	shell="${args[1]}"
+	if [[ -z $shell ]]; then
+		echo "Please supply a shell."
+		echo "    eg. wt init bash"
+		exit 1
+	fi
+	case "$shell" in
+	bash|zsh)
+		init_bash
+		;;
+	fish)
+		init_fish
+		;;
+	*)
+		echo "Unsupported shell: $shell"
+		exit 1
+		;;
+	esac
+}
+
 if [ -z "${args[0]}" ]; then
 	help_message
 	exit 0
@@ -95,6 +158,9 @@ help)
 version)
 	echo Version: $VERSION
 	;;
+init)
+	init
+	;;
 -)
 	goto_main_worktree
 	;;
@@ -103,16 +169,9 @@ version)
 	;;
 esac
 
-# Change worktree based on user argument.
-change_worktree() {
-	echo Changing to worktree at: "$directory"
-	cd "$directory"
-	exec $SHELL
-}
-
 # If directory variable is not empty then change worktree
 if [ -z "$directory" ]; then
 	:
 else
-	change_worktree
+	echo "$CHANGE_DIRECTORY_PREFIX$directory"
 fi

--- a/wt
+++ b/wt
@@ -81,7 +81,7 @@ init_bash() {
 	cat <<EOF
 wt() {
 	if ! command -v wt &> /dev/null; then
-		echo "wt was not found in your \\\$PATH"
+		echo 'wt was not found in your \$PATH'
 		return 1
 	fi
 
@@ -103,7 +103,7 @@ init_fish() {
 	cat <<EOF
 function wt
 	if ! command -q wt
-		echo "wt was not found in your \\\$PATH"
+		echo 'wt was not found in your \$PATH'
 		return 1
 	end
 


### PR DESCRIPTION
This PR creates shell functions that invoke `wt` and cd into the given directory. This partially solves #11.

What changed:
- When running `wt` and giving it a valid worktree name, it `echo`'s out `changedir:<path>`.
- Adds the `init` sub-command for generating the shell code of the function.
- The installation now requires the addition of a line to the shell config that invokes wt and runs the generated code. This is reflected in the readme.

I believe some further changes would be nice, but might be outside the scope of this PR:
- Add a `--` prefix for the sub-commands, to avoid collisions with worktree names.
- The new `init` operation could also generate the completion scripts to reduce installation complexity. (This could be implemented in this PR)
- Shell completions could include the sub-commands.

Some notes:
- This introduces breaking changes, because the installation changed.
- Instead of the shell function invoking `wt`, the whole script could be inside the shell function, thus not needing the ugly echoing.
- The error messages are not the best...
- Maybe the whole thing should be refactored :)
